### PR TITLE
Fix: Replaced GPT-3.5 Turbo[Deprecated] with GPT-4o

### DIFF
--- a/srv/chat-service.js
+++ b/srv/chat-service.js
@@ -16,7 +16,7 @@ module.exports = class ChatService extends cds.ApplicationService {
                     { role: "system", content: "You are a helpful assistant." },
                     { role: "user", content: request }
                 ],
-                model: "gpt-3.5-turbo",
+                model: "gpt-4o",
               });
 
             console.log(response);
@@ -30,7 +30,7 @@ module.exports = class ChatService extends cds.ApplicationService {
             const request = req.data.input;
             const openai = await cds.connect.to('OpenAI.Chat.Completion.API');
             const data = {
-                "model": "gpt-3.5-turbo",
+                "model": "gpt-4o",
                 "messages": [
                     { role: "system", content: "You are a helpful assistant." },
                     { role: "user", content: request }


### PR DESCRIPTION
Replaced GPT-3.5 Turbo with GPT-4o as OpenAI is going to shut down GPT-3.5 in September 2024.

![image](https://github.com/user-attachments/assets/79e567a7-b6b0-4923-b276-f30a90f8b077)
